### PR TITLE
Updates to fix two typos in two figures

### DIFF
--- a/submissions/Surveying_The_Avalanche.Rmd
+++ b/submissions/Surveying_The_Avalanche.Rmd
@@ -1433,7 +1433,7 @@ rbind(bbm3_wr_heavy_through7, bbm3_wr_heavy_through9) %>%
               decimals = 2) %>%
   # Footnotes
   tab_footnote(
-    footnote = "Utilization is how often drafters had X wide receivers through seven or ten rounds.",
+    footnote = "Utilization is how often drafters had X wide receivers through seven or nine rounds.",
     locations = cells_column_labels(columns = c("utilization"))
   ) %>%
   tab_footnote(
@@ -1466,7 +1466,7 @@ rbind(bbm3_wr_heavy_through7, bbm3_wr_heavy_through9) %>%
 ```
 
 ```{r echo=FALSE, message=FALSE, warning=FALSE}
-knitr::include_graphics("https://raw.githubusercontent.com/thefalkon-1/bbm-data-bowl-tables/main/table6.png", dpi = 200)
+knitr::include_graphics("https://raw.githubusercontent.com/thefalkon-1/bbm-data-bowl-tables/main/table6v2.png", dpi = 200)
 ```
 
 Before drawing conclusions, let's also look at BBM2.
@@ -1563,7 +1563,7 @@ rbind(bbm2_wr_heavy_through7, bbm2_wr_heavy_through9) %>%
               decimals = 2) %>%
   # Footnotes
   tab_footnote(
-    footnote = "Utilization is how often drafters had X wide receivers through seven or ten rounds.",
+    footnote = "Utilization is how often drafters had X wide receivers through seven or nine rounds.",
     locations = cells_column_labels(columns = c("utilization"))
   ) %>%
   tab_footnote(
@@ -1591,7 +1591,7 @@ rbind(bbm2_wr_heavy_through7, bbm2_wr_heavy_through9) %>%
 ```
 
 ```{r echo=FALSE, message=FALSE, warning=FALSE}
-knitr::include_graphics("https://raw.githubusercontent.com/thefalkon-1/bbm-data-bowl-tables/main/table7.png", dpi = 200)
+knitr::include_graphics("https://raw.githubusercontent.com/thefalkon-1/bbm-data-bowl-tables/main/table7v2.png", dpi = 200)
 ```
 
 The following conclusions should be taken with a grain of salt, as the sample size is limited to 5% of drafts from BBM2 and BBM3. While drafting either four or five WRs by Round 7 and Round 9 underperformed how a team scored during the regular season, both strategies appear to remain optimal in WR-heavy rooms. Notably, drafting more WRs and drafting them earlier [seemed optimal for regular season scoring in BBM3](https://underdognetwork.com/_next/image?url=https%3A%2F%2Fimages.ctfassets.net%2Fl8eoog2wur2i%2F6UwDhRFtH21lpnaHKojFrV%2Fca6915069d920fc53bd1c444cd51466c%2FBBM3WROptimal.png&w=3840&q=75), but that held less firmly in WR-heavy rooms.

--- a/submissions/Surveying_The_Avalanche.md
+++ b/submissions/Surveying_The_Avalanche.md
@@ -588,8 +588,6 @@ ggplot(data = wr_run_length_dist, aes(x = wr_run_length)) +
 ggsave("figure2.png")
 ```
 
-    ## Saving 9 x 4 in image
-
 ![](https://raw.githubusercontent.com/thefalkon-1/bbm-data-bowl-tables/main/figure2.png)<!-- -->
 
 **How does a wide receiver run affect ADP?**
@@ -1570,7 +1568,7 @@ rbind(bbm3_wr_heavy_through7, bbm3_wr_heavy_through9) %>%
   gtsave_extra(filename = "table6.png")
 ```
 
-![](https://raw.githubusercontent.com/thefalkon-1/bbm-data-bowl-tables/main/table6.png)<!-- -->
+![](https://raw.githubusercontent.com/thefalkon-1/bbm-data-bowl-tables/main/table6v2.png)<!-- -->
 
 Before drawing conclusions, let’s also look at BBM2.
 
@@ -1693,7 +1691,7 @@ rbind(bbm2_wr_heavy_through7, bbm2_wr_heavy_through9) %>%
   gtsave_extra(filename = "table7.png")
 ```
 
-![](https://raw.githubusercontent.com/thefalkon-1/bbm-data-bowl-tables/main/table7.png)<!-- -->
+![](https://raw.githubusercontent.com/thefalkon-1/bbm-data-bowl-tables/main/table7v2.png)<!-- -->
 
 The following conclusions should be taken with a grain of salt, as the
 sample size is limited to 5% of drafts from BBM2 and BBM3. While


### PR DESCRIPTION
I changed two footnotes in two tables that mistakenly said "through 10 rounds" instead of "through nine rounds". The data is the same -- just a typo on my end. I also deleted one "saving" message that should have not appeared.